### PR TITLE
goog.string.format needs to be required or else it's elided

### DIFF
--- a/src/om_i/core.cljs
+++ b/src/om_i/core.cljs
@@ -3,6 +3,7 @@
             [goog]
             [goog.dom]
             [goog.string :as gstring]
+            [goog.string.format]
             [om.core :as om :include-macros true]
             [om.dom :as dom :include-macros true]
             [om-i.keyboard :as keyboard]


### PR DESCRIPTION
Following the readme instructions on a fresh mies-om app, I got an undefined is not a function for `goog.string.format`. It seems that [goog.string.format](http://docs.closure-library.googlecode.com/git/local_closure_goog_string_stringformat.js.source.html#line25) is unusual in that it's a namespace used by the format function and thus requires a separate require declaration. If you want confirmation of this, see [this was also done](https://github.com/clojure/clojurescript/commit/48c8d0fafc18375876e10caf960a7c7da27ac308) in clojurescript.

To reproduce the error I was seeing, `lein new mies-om om-test`, add precursor 0.1.3 as a dependency and use this core.cljs:

``` cljs
(ns om-test.core
  (:require [om.core :as om]
            [om.dom :as dom]
            [om-i.hacks]
            [om-i.core]))

(enable-console-print!)

(def app-state (atom {:text "Hello world!"}))

(om/root
  (fn [app owner]
    (reify om/IRender
      (render [_]
        (dom/h1 nil (:text app)))))
  app-state
  {:target (. js/document (getElementById "app"))
   :instrument (fn [f cursor m]
                 (om/build* f cursor
                            (assoc m
                                   :descriptor om-i.core/instrumentation-methods)))})

(om-i.core/setup-component-stats!)
(om-i.hacks/insert-styles)
```

Thanks for the handy lib!
